### PR TITLE
Added pdpgo library with wrappers about libpdp methods (only A-PDP is now supported). Fixed several libpdp bugs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ tools/test-files/*
 *.out
 *.app
 
+# Idea project
+.idea/*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean distclean doc
+.PHONY: all clean distclean doc libpdpgo
 
 VPATH  +=
 
@@ -25,6 +25,10 @@ bench: libpdp
 	@echo "Building the pdp_bench benchmarking utility"
 	$(MAKE) -C tools pdp_bench
 
+libpdpgo:
+	@echo "Building the libpdpgo"
+	$(MAKE) -C libpdpgo all
+
 doc: doxyfile
 	doxygen doxyfile
 
@@ -32,9 +36,11 @@ clean:
 	[ -d tools ] && $(MAKE) -C tools clean
 	[ -d libpdp ] && $(MAKE) -C libpdp clean
 	[ -d libs3 ] && $(MAKE) -C libs3 clean
+	[ -d libpdpgo ] && $(MAKE) -C libpdpgo clean
 
 distclean: clean
 	[ -d tools ] && $(MAKE) -C tools distclean
 	[ -d libpdp ] && $(MAKE) -C libpdp distclean
 	[ -d libs3 ] && $(MAKE) -C libs3 distclean
+	[ -d libpdpgo ] && $(MAKE) -C libpdpgo distclean
 	rm -rf doc/html

--- a/libpdp/inc/pdp.h
+++ b/libpdp/inc/pdp.h
@@ -50,6 +50,7 @@
 #define PDP_USE_ECC      0x04   ///< Use an ECC tranform before tagging
 #define PDP_OPT_HTTPS    0x08   ///< Force using HTTPS
 #define PDP_PW_NOINPUT   0x10   ///< Read password from environment (not safe)
+#define PDP_OPT_EXT_STRG 0x20   ///< Use external function to access storage backend
 
 /*
  * function prototypes
@@ -58,8 +59,10 @@ int pdp_ctx_init(pdp_ctx_t *ctx);
 int pdp_ctx_create(pdp_ctx_t *ctx, const char* filename, const char *output);
 int pdp_ctx_free(pdp_ctx_t *ctx);
 int pdp_key_open(pdp_ctx_t *ctx, pdp_key_t *key, pdp_key_t *pk,
-        const char *path);
-int pdp_key_store(const pdp_ctx_t *ctx, const pdp_key_t *key, const char *path);
+        const char *path, const unsigned char* pri_key_buffer, const unsigned char* pub_key_buffer);
+int pdp_key_store(const pdp_ctx_t *ctx, const pdp_key_t *key, const char *path,
+        unsigned char** pri_key_buffer, unsigned int* pri_key_buffer_length,
+        unsigned char** pub_key_buffer, unsigned int* pub_key_buffer_length);
 int pdp_key_gen(pdp_ctx_t *ctx, pdp_key_t *key, pdp_key_t *pk);
 int pdp_key_free(const pdp_ctx_t *ctx, pdp_key_t *key);
 int pdp_file_preprocess(pdp_ctx_t *ctx);

--- a/libpdp/inc/pdp/apdp.h
+++ b/libpdp/inc/pdp/apdp.h
@@ -62,9 +62,11 @@ int apdp_ctx_init(pdp_ctx_t *ctx);
 int apdp_ctx_create(pdp_ctx_t *ctx);
 int apdp_ctx_free(pdp_ctx_t *ctx);
 int apdp_key_gen(const pdp_ctx_t *ctx, pdp_key_t *k, pdp_key_t *pub);
-int apdp_key_store(const pdp_ctx_t *ctx, const pdp_key_t *k, const char *path);
-int apdp_key_open(const pdp_ctx_t *ctx, pdp_key_t *k, pdp_key_t *pub, 
-        const char* path);
+int apdp_key_store(const pdp_ctx_t *ctx, const pdp_key_t *k, const char *path,
+        unsigned char** pri_key_buffer, unsigned int* pri_key_buffer_length,
+        unsigned char** pub_key_buffer, unsigned int* pub_key_buffer_length);
+int apdp_key_open(const pdp_ctx_t *ctx, pdp_key_t *k, pdp_key_t *pub, const char* path,
+        const unsigned char* pri_key_buffer, const unsigned char* pub_key_buffer);
 int apdp_key_free(const pdp_ctx_t *ctx, pdp_key_t *k);
 int apdp_tags_gen(pdp_ctx_t *ctx, pdp_apdp_key_t *k, pdp_apdp_tagdata_t *t);
 int apdp_tags_free(const pdp_ctx_t *ctx, pdp_apdp_tagdata_t *t);

--- a/libpdp/inc/pdp/types.h
+++ b/libpdp/inc/pdp/types.h
@@ -62,6 +62,7 @@ typedef struct {
     } __pdp_ctx_param_u;
 
     struct pdp_ctx_ops *ops;
+    void* optional_data;
 } pdp_ctx_t;
 
 

--- a/libpdp/src/apdp/apdp.c
+++ b/libpdp/src/apdp/apdp.c
@@ -223,7 +223,7 @@ cleanup:
  * @param[out]    t           *t is a pointer to a filled-out tag
  * @return 0 on success, non-zero on error
  **/
-static int apdp_tag_block(pdp_ctx_t *ctx, pdp_apdp_key_t *key,
+int apdp_tag_block(pdp_ctx_t *ctx, pdp_apdp_key_t *key,
                           unsigned char *block, size_t block_len,
                           int index, pdp_apdp_tag_t **t)
 {
@@ -800,7 +800,6 @@ finalize:
     proof->rho = gen_bn_H(proof->rho_temp, &(proof->rho_size));
     if (!proof->rho) goto cleanup;
     status = 0;
-    goto cleanup;
 
 cleanup:
     if (coefficient_a) BN_clear_free(coefficient_a);

--- a/libpdp/src/apdp/apdp_misc.h
+++ b/libpdp/src/apdp/apdp_misc.h
@@ -21,6 +21,8 @@
     memcpy(BUF, &value, sizeof(__uint32_t));                \
     BUF += sizeof(__uint32_t);
 
+unsigned int get_num_blocks(off_t file_st_size, unsigned int block_size);
+
 /*
  * function prototypes - apdp.c
  */
@@ -43,6 +45,10 @@ int apdp_serialize_proof(const pdp_ctx_t *ctx, const pdp_apdp_proof_t* t,
         unsigned char **buffer, unsigned int *buffer_len);
 int apdp_deserialize_proof(const pdp_ctx_t *ctx, pdp_apdp_proof_t* tag,
         const unsigned char *buffer, unsigned int buffer_len);
+
+int apdp_tag_block(pdp_ctx_t *ctx, pdp_apdp_key_t *key,
+                   unsigned char *block, size_t block_len,
+                   int index, pdp_apdp_tag_t **t);
 
 #endif
 /** @} */

--- a/libpdp/src/apdp/apdp_misc.h
+++ b/libpdp/src/apdp/apdp_misc.h
@@ -16,6 +16,11 @@
 #define __A_PDP_MISC_H__
 
 
+#define WRITE_UINT32(BUF, VALUE)                            \
+    value = uint32_to_little_endian((__uint32_t)VALUE);     \
+    memcpy(BUF, &value, sizeof(__uint32_t));                \
+    BUF += sizeof(__uint32_t);
+
 /*
  * function prototypes - apdp.c
  */
@@ -30,6 +35,14 @@ int apdp_serialize_tags(const pdp_ctx_t *ctx, const pdp_apdp_tagdata_t* t,
         unsigned char **buffer, unsigned int *buffer_len);
 int apdp_deserialize_tag(const pdp_ctx_t *ctx, pdp_apdp_tag_t* tag,
         unsigned char *buffer, unsigned int buffer_len);
+int apdp_serialize_challenge(const pdp_ctx_t *ctx, const pdp_apdp_challenge_t* t,
+        unsigned char **buffer, unsigned int *buffer_len);
+int apdp_deserialize_challenge(const pdp_ctx_t *ctx, pdp_apdp_challenge_t* tag,
+        const unsigned char *buffer, unsigned int buffer_len);
+int apdp_serialize_proof(const pdp_ctx_t *ctx, const pdp_apdp_proof_t* t,
+        unsigned char **buffer, unsigned int *buffer_len);
+int apdp_deserialize_proof(const pdp_ctx_t *ctx, pdp_apdp_proof_t* tag,
+        const unsigned char *buffer, unsigned int buffer_len);
 
 #endif
 /** @} */

--- a/libpdp/src/apdp/apdp_serialize.c
+++ b/libpdp/src/apdp/apdp_serialize.c
@@ -36,8 +36,8 @@ unsigned int apdp_serialized_tag_size(const pdp_ctx_t *ctx)
     if (!is_apdp(ctx)) return -1;
     p = ctx->apdp_param;
 
-    return (sizeof(size_t) + (p->rsa_key_size + 7)/8 + sizeof(unsigned int) + 
-            sizeof(size_t) + p->prf_w_size);
+    return (sizeof(__uint32_t) + (p->rsa_key_size + 7)/8 + sizeof(unsigned int) +
+            sizeof(__uint32_t) + p->prf_w_size);
 }
 
 
@@ -56,7 +56,6 @@ int apdp_serialize_tags(const pdp_ctx_t *ctx, const pdp_apdp_tagdata_t* t,
 {
     pdp_apdp_ctx_t *p = NULL;
     pdp_apdp_tag_t *tag = NULL;
-    FILE *tagfile = NULL;
     unsigned char *buf_ptr = NULL;
     unsigned char *buf = NULL;
     unsigned char *tim = NULL;
@@ -64,6 +63,7 @@ int apdp_serialize_tags(const pdp_ctx_t *ctx, const pdp_apdp_tagdata_t* t,
     size_t tag_size, prf_size, buf_len;
     size_t tim_size, tim_len = 0;
     int i, status = -1;
+    __uint32_t value;
 
     if (!is_apdp(ctx) || !t || !buffer || !buffer_len ||
                          !t->tags || !t->tags_num || !t->tags_size)
@@ -87,7 +87,7 @@ int apdp_serialize_tags(const pdp_ctx_t *ctx, const pdp_apdp_tagdata_t* t,
 
     for(i = 0; i < t->tags_num; i++) {
         tag = t->tags[i];
-        memset(tim, 0, tim_len);
+        memset(tim, 0, tim_size);
         memset(prf, 0, prf_size);
 
         // get real Tim byte len
@@ -98,8 +98,7 @@ int apdp_serialize_tags(const pdp_ctx_t *ctx, const pdp_apdp_tagdata_t* t,
         if (tag->index_prf_size > prf_size) goto cleanup;
 
         // write Tim size
-        memcpy(buf_ptr, &tim_len, sizeof(tim_len));
-        buf_ptr += sizeof(tim_len);
+        WRITE_UINT32(buf_ptr, tim_size)
         
         // write Tim
         if (!BN_bn2bin(tag->Tim, tim)) goto cleanup;
@@ -107,12 +106,10 @@ int apdp_serialize_tags(const pdp_ctx_t *ctx, const pdp_apdp_tagdata_t* t,
         buf_ptr += tim_size;
 
         // write index
-        memcpy(buf_ptr, &(tag->index), sizeof(tag->index));
-        buf_ptr += sizeof(tag->index);
+        WRITE_UINT32(buf_ptr, tag->index)
         
         // write index_prf_size
-        memcpy(buf_ptr, &(tag->index_prf_size), sizeof(tag->index_prf_size));
-        buf_ptr += sizeof(tag->index_prf_size);
+        WRITE_UINT32(buf_ptr, tag->index_prf_size)
 
         // write index_prf
         memcpy(prf, tag->index_prf, tag->index_prf_size);
@@ -120,26 +117,30 @@ int apdp_serialize_tags(const pdp_ctx_t *ctx, const pdp_apdp_tagdata_t* t,
         buf_ptr += prf_size;
 
 #ifdef _PDP_DEBUG
-        DEBUG(1, "\n Writing - ");
-        DEBUG(1, "\n Tag %02d", i);
-        DEBUG(1, "\n  Tim byte len [%02d]", BN_num_bytes(tag->Tim));
-        DEBUG(1, "\n  Tim (hex) [%s]", BN_bn2hex(tag->Tim));
-        DEBUG(1, "\n  index [%d]",  tag->index);
-        DEBUG(1, "\n  prf_size [%d]", tag->index_prf_size);
-        pdp_hexdump("  prf", i, tag->index_prf, tag->index_prf_size);
-        pdp_hexdump(" Ser. tag", i, buf_ptr - tag_size, tag_size);
+//        DEBUG(1, "\n Writing - ");
+//        DEBUG(1, "\n Tag %02d", i);
+//        DEBUG(1, "\n  Tim byte len [%02d]", BN_num_bytes(tag->Tim));
+//        DEBUG(1, "\n  Tim (hex) [%s]", BN_bn2hex(tag->Tim));
+//        DEBUG(1, "\n  index [%d]",  tag->index);
+//        DEBUG(1, "\n  prf_size [%lud]", tag->index_prf_size);
+//        pdp_hexdump("  prf", i, tag->index_prf, tag->index_prf_size);
+//        pdp_hexdump(" Ser. tag", i, buf_ptr - tag_size, tag_size);
 #endif // _PDP_DEBUG
 
     }
+
     *buffer = buf;
     *buffer_len = buf_len;
     status = 0;
 
 cleanup:
-    if (tagfile) fclose(tagfile);
     sfree(tim, tim_size);
     sfree(prf, prf_size);
-    if (status) sfree(buf, buf_len);
+    if (status && buf) {
+        sfree(buf, buf_len);
+        *buffer = NULL;
+        *buffer_len = 0;
+    }
     return status;
 }
 
@@ -159,7 +160,7 @@ int apdp_deserialize_tag(const pdp_ctx_t *ctx, pdp_apdp_tag_t* tag,
     unsigned char *buf_ptr = buf;
     unsigned char *tim = NULL;
     size_t tag_size, prf_size;
-    size_t tim_size, tim_len = 0;
+    size_t tim_size = 0;
     int status = -1;
     
     if (!is_apdp(ctx) || !tag || !buf || !buf_len)
@@ -168,29 +169,28 @@ int apdp_deserialize_tag(const pdp_ctx_t *ctx, pdp_apdp_tag_t* tag,
 
     // some useful constants: upper bounds on sizes of things
     tag_size = apdp_serialized_tag_size(ctx);
-    tim_size = (p->rsa_key_size + 7)/8; // Tim is max size log2(rsa->n)
     prf_size = p->prf_w_size;
 
     // double-check size of buf
     if (!tag_size || (buf_len > tag_size)) goto cleanup;
 
     // read Tim size
-    memcpy(&tim_len, buf_ptr, sizeof(tim_len));
-    buf_ptr += sizeof(tim_len);
+    tim_size = uint32_in_expected_order(buf_ptr);
+    buf_ptr += sizeof(__uint32_t);
 
     // read Tim
-    if ((tim = malloc(tim_len)) == NULL) goto cleanup;
-    memset(tim, 0, tim_len);
-    memcpy(tim, buf_ptr, tim_len);
+    if ((tim = malloc(tim_size)) == NULL) goto cleanup;
+    memset(tim, 0, tim_size);
+    memcpy(tim, buf_ptr, tim_size);
     buf_ptr += tim_size; // skip bytes of serialized Tim size
-    if (!BN_bin2bn(tim, tim_len, tag->Tim)) goto cleanup;
+    if (!BN_bin2bn(tim, tim_size, tag->Tim)) goto cleanup;
 
     // read index
-    memcpy(&(tag->index), buf_ptr, sizeof(tag->index));
+    tag->index = uint32_in_expected_order(buf_ptr);
     buf_ptr += sizeof(tag->index);
     
     // read index_prf_size
-    memcpy(&(tag->index_prf_size), buf_ptr, sizeof(tag->index_prf_size));
+    tag->index_prf_size = uint32_in_expected_order(buf_ptr);
     buf_ptr += sizeof(tag->index_prf_size);
 
     // double check size of prf
@@ -200,13 +200,312 @@ int apdp_deserialize_tag(const pdp_ctx_t *ctx, pdp_apdp_tag_t* tag,
     if ((tag->index_prf = malloc(tag->index_prf_size)) == NULL) goto cleanup;
     memset(tag->index_prf, 0, tag->index_prf_size);
     memcpy(tag->index_prf, buf_ptr, tag->index_prf_size);
-    buf_ptr += tag->index_prf_size;
 
     status = 0;
 
 cleanup:
-    sfree(tim, tim_len);
+    sfree(tim, tim_size);
     return status;
+}
+
+
+/**
+ * @brief Write out challenge data to a buffer
+ *
+ * @param[in]  ctx         context
+ * @param[in]  t           pointer to input challenge data
+ * @param[in]  buffer      the buffer for the serialized data
+ * @param[in]  buffer_len  length of space available, output bytes written
+ * @return 0 on success, non-zero on error
+ **/
+int apdp_serialize_challenge(const pdp_ctx_t *ctx, const pdp_apdp_challenge_t* t,
+        unsigned char **buffer, unsigned int *buffer_len)
+{
+    pdp_apdp_ctx_t *p = NULL;
+    unsigned char *buf_ptr = NULL;
+    unsigned char *buf = NULL;
+    unsigned char *g_s_buf = NULL;
+    unsigned char *s_buf = NULL;
+    size_t buf_len = 0;
+    size_t g_s_len = 0;
+    size_t s_len = 0;
+    int status = -1;
+    __uint32_t value;
+
+    if (!is_apdp(ctx) || !t || !buffer || !buffer_len ||
+        !t->g_s || !t->k1 || !t->k2)
+        return -1;
+    p = ctx->apdp_param;
+
+    // Calculate 'g_s' length and allocate space for it.
+    g_s_len = BN_num_bytes(t->g_s);
+    if ((g_s_buf = malloc(g_s_len)) == NULL) goto cleanup;
+    memset(g_s_buf, 0, g_s_len);
+
+    // Calculate 's' length and allocate space for it.
+    if (t->s) {
+        s_len = BN_num_bytes(t->s);
+        if ((s_buf = malloc(s_len)) == NULL) goto cleanup;
+        memset(s_buf, 0, s_len);
+    }
+
+    // Calculate serialized challenge length and allocate space for it.
+    buf_len = g_s_len + s_len + 5 * sizeof(__uint32_t) + p->prp_key_size + p->prf_key_size;
+    if ((buf = malloc(buf_len)) == NULL) goto cleanup;
+    memset(buf, 0, buf_len);
+    buf_ptr = buf;
+
+    // Write 'c'.
+    WRITE_UINT32(buf_ptr, t->c)
+
+    // Write length of 'g_s'.
+    WRITE_UINT32(buf_ptr, g_s_len)
+
+    // Write 'g_s'.
+    if (!BN_bn2bin(t->g_s, g_s_buf)) goto cleanup;
+    memcpy(buf_ptr, g_s_buf, g_s_len);
+    buf_ptr += g_s_len;
+
+    // Write length of 's'.
+    WRITE_UINT32(buf_ptr, s_len)
+
+    // Write 's'.
+    if (t->s) {
+        if (!BN_bn2bin(t->s, s_buf)) goto cleanup;
+        memcpy(buf_ptr, s_buf, s_len);
+        buf_ptr += s_len;
+    }
+
+    // Write length of 'k1'.
+    WRITE_UINT32(buf_ptr, p->prp_key_size)
+
+    // Write 'k1'.
+    memcpy(buf_ptr, t->k1, p->prp_key_size);
+    buf_ptr += p->prp_key_size;
+
+    // Write length of 'k2'.
+    WRITE_UINT32(buf_ptr, p->prf_key_size)
+
+    // Write 'k2'.
+    memcpy(buf_ptr, t->k2, p->prf_key_size);
+    buf_ptr += p->prf_key_size;
+
+    *buffer = buf;
+    *buffer_len = buf_len;
+
+    status = 0;
+
+cleanup:
+    sfree(g_s_buf, g_s_len);
+    sfree(s_buf, s_len);
+    if (status && buf) {
+        sfree(buf, buf_len);
+        *buffer = NULL;
+        *buffer_len = 0;
+    }
+
+    return status;
+}
+
+
+/**
+ * @brief Read a challenge
+ * @param[in]  ctx         context
+ * @param[out] t           pointer to challenge that will be populated
+ * @param[in]  buffer      serialized structure to process
+ * @param[in]  buffer_len  length of data to process
+ * @return 0 on success, non-zero on error
+ **/
+int apdp_deserialize_challenge(const pdp_ctx_t *ctx, pdp_apdp_challenge_t* t,
+                               const unsigned char *buffer, unsigned int buffer_len)
+{
+    pdp_apdp_ctx_t *p = NULL;
+    const unsigned char *buf_ptr = buffer;
+    size_t g_s_len = 0;
+    size_t s_len = 0;
+
+    if (!is_apdp(ctx) || !t || !buffer)
+        return -1;
+    p = ctx->apdp_param;
+
+    // Read 'c'.
+    t->c = uint32_in_expected_order(buf_ptr);
+    buf_ptr += sizeof(__uint32_t);
+
+    // Read 'g_s' size.
+    g_s_len = uint32_in_expected_order(buf_ptr);
+    buf_ptr += sizeof(__uint32_t);
+
+    // Read 'g_s'.
+    if ((t->g_s = BN_bin2bn(buf_ptr, g_s_len, NULL)) == NULL)
+        return -1;
+    buf_ptr += g_s_len;
+
+    // Read 's' size.
+    s_len = uint32_in_expected_order(buf_ptr);
+    buf_ptr += sizeof(__uint32_t);
+
+    // Read 's'.
+    if (s_len) {
+        if ((t->s = BN_bin2bn(buf_ptr, s_len, NULL)) == NULL)
+            return -1;
+        buf_ptr += s_len;
+    }
+
+    // Read 'prp_key_size'.
+    p->prp_key_size = uint32_in_expected_order(buf_ptr);
+    buf_ptr += sizeof(__uint32_t);
+
+    // Allocate and read 'k1'.
+    if ((t->k1 = malloc(p->prp_key_size)) == NULL)
+        return -1;
+    memset(t->k1, 0, p->prp_key_size);
+    memcpy(t->k1, buf_ptr, p->prp_key_size);
+    buf_ptr += p->prp_key_size;
+
+    // Read 'prf_key_size'.
+    p->prf_key_size = uint32_in_expected_order(buf_ptr);
+    buf_ptr += sizeof(__uint32_t);
+
+    // Read 'k2'.
+    if ((t->k2 = malloc(p->prf_key_size)) == NULL)
+        return -1;
+    memset(t->k2, 0, p->prf_key_size);
+    memcpy(t->k2, buf_ptr, p->prf_key_size);
+
+    return 0;
+}
+
+
+/**
+ * @brief Write out proof data to a buffer
+ *
+ * @param[in]  ctx         context
+ * @param[in]  t           pointer to input proof data
+ * @param[in]  buffer      the buffer for the serialized data
+ * @param[in]  buffer_len  length of space available, output bytes written
+ * @return 0 on success, non-zero on error
+ **/
+int apdp_serialize_proof(const pdp_ctx_t *ctx, const pdp_apdp_proof_t* t,
+                             unsigned char **buffer, unsigned int *buffer_len)
+{
+    unsigned char *buf_ptr = NULL;
+    unsigned char *buf = NULL;
+    unsigned char *rho_temp_buf = NULL;
+    unsigned char *T_buf = NULL;
+    size_t buf_len = 0;
+    size_t rho_temp_len = 0;
+    size_t T_len = 0;
+    int status = -1;
+    __uint32_t value;
+
+    if (!is_apdp(ctx) || !t || !buffer || !buffer_len ||
+        !t->T || !t->rho_temp || !t->rho)
+        return -1;
+
+    // Calculate length of 'T' and allocate space for it.
+    T_len = BN_num_bytes(t->T);
+    if ((T_buf = malloc(T_len)) == NULL) goto cleanup;
+    memset(T_buf, 0, T_len);
+
+    // Calculate length of 'rho_temp' and allocate space for it.
+    rho_temp_len = BN_num_bytes(t->rho_temp);
+    if ((rho_temp_buf = malloc(rho_temp_len)) == NULL) goto cleanup;
+    memset(rho_temp_buf, 0, rho_temp_len);
+
+    // Calculate length of serialized proof and allocate space for it.
+    buf_len = T_len + rho_temp_len + 3 * sizeof(__uint32_t) + t->rho_size;
+    if ((buf = malloc(buf_len)) == NULL) goto cleanup;
+    memset(buf, 0, buf_len);
+    buf_ptr = buf;
+
+    // Write length of 'T'.
+    WRITE_UINT32(buf_ptr, T_len)
+
+    // Write 's'.
+    if (!BN_bn2bin(t->T, T_buf)) goto cleanup;
+    memcpy(buf_ptr, T_buf, T_len);
+    buf_ptr += T_len;
+
+    // Write length of 'rho_temp'.
+    WRITE_UINT32(buf_ptr, rho_temp_len)
+
+    // Write 'rho_temp'.
+    if (!BN_bn2bin(t->rho_temp, rho_temp_buf)) goto cleanup;
+    memcpy(buf_ptr, rho_temp_buf, rho_temp_len);
+    buf_ptr += rho_temp_len;
+
+    // Write length of 'rho'.
+    WRITE_UINT32(buf_ptr, t->rho_size)
+
+    // Write 'rho'.
+    memcpy(buf_ptr, t->rho, t->rho_size);
+
+    *buffer = buf;
+    *buffer_len = buf_len;
+
+    status = 0;
+
+cleanup:
+    sfree(rho_temp_buf, rho_temp_len);
+    sfree(T_buf, T_len);
+    if (status && buf) {
+        sfree(buf, buf_len);
+        *buffer = NULL;
+        *buffer_len = 0;
+    }
+
+    return status;
+}
+
+
+/**
+ * @brief Read a proof
+ * @param[in]  ctx         context
+ * @param[out] t           pointer to proof that will be populated
+ * @param[in]  buffer      serialized structure to process
+ * @param[in]  buffer_len  length of data to process
+ * @return 0 on success, non-zero on error
+ **/
+int apdp_deserialize_proof(const pdp_ctx_t *ctx, pdp_apdp_proof_t* t,
+                               const unsigned char *buffer, unsigned int buffer_len)
+{
+    const unsigned char *buf_ptr = buffer;
+    size_t rho_temp_len = 0;
+    size_t T_len = 0;
+
+    if (!is_apdp(ctx) || !t || !buffer)
+        return -1;
+
+    // Read size of 'T'.
+    T_len = uint32_in_expected_order(buf_ptr);
+    buf_ptr += sizeof(__uint32_t);
+
+    // Read 'T'.
+    if ((t->T = BN_bin2bn(buf_ptr, T_len, NULL)) == NULL)
+        return -1;
+    buf_ptr += T_len;
+
+    // Read length of 'rho_temp'.
+    rho_temp_len = uint32_in_expected_order(buf_ptr);
+    buf_ptr += sizeof(__uint32_t);
+
+    // Read 'rho_temp'.
+    if ((t->rho_temp = BN_bin2bn(buf_ptr, rho_temp_len, NULL)) == NULL)
+        return -1;
+    buf_ptr += rho_temp_len;
+
+    // Read 'rho_size'.
+    t->rho_size = uint32_in_expected_order(buf_ptr);
+    buf_ptr += sizeof(__uint32_t);
+
+    // Allocate and read 'rho'.
+    if ((t->rho = malloc(t->rho_size)) == NULL)
+        return -1;
+    memset(t->rho, 0, t->rho_size);
+    memcpy(t->rho, buf_ptr, t->rho_size);
+
+    return 0;
 }
 
 /** @} */

--- a/libpdp/src/cpor/cpor_key.c
+++ b/libpdp/src/cpor/cpor_key.c
@@ -434,8 +434,8 @@ int cpor_fkey_open(const pdp_ctx_t *ctx, const pdp_cpor_key_t *key,
 
 #ifdef _PDP_DEBUG
     DEBUG(1, "\n Read Key File - ");
-    DEBUG(1, "\n  CTXT Length [%d]",  ctxt_len);
-    DEBUG(1, "\n  MAC Length [%d]",  mac_len);
+    DEBUG(1, "\n  CTXT Length [%lu]",  ctxt_len);
+    DEBUG(1, "\n  MAC Length [%lu]",  mac_len);
     DEBUG(1, "\n  Num Sectors Length [%d]",  p->num_sectors);
     for(i=0; i < p->num_sectors; i++) {
         DEBUG(1, "\n Sector %02d", i);
@@ -580,8 +580,8 @@ int cpor_fkey_store(const pdp_ctx_t *ctx, const pdp_cpor_key_t *key,
 
 #ifdef _PDP_DEBUG
     DEBUG(1, "\n Wrote Key File - ");
-    DEBUG(1, "\n  CTXT Length [%d]",  k_ctxt_len);
-    DEBUG(1, "\n  MAC Length [%d]",  k_mac_len);
+    DEBUG(1, "\n  CTXT Length [%lu]",  k_ctxt_len);
+    DEBUG(1, "\n  MAC Length [%lu]",  k_mac_len);
     DEBUG(1, "\n  Num Sectors Length [%d]",  p->num_sectors);
     for(i=0; i < p->num_sectors; i++) {
         DEBUG(1, "\n Sector %02d", i);

--- a/libpdp/src/mrpdp/mrpdp_serialize.c
+++ b/libpdp/src/mrpdp/mrpdp_serialize.c
@@ -124,7 +124,7 @@ int mrpdp_serialize_tags(const pdp_ctx_t *ctx, const pdp_mrpdp_tagdata_t* t,
         DEBUG(1, "\n  Tim byte len [%02d]", BN_num_bytes(tag->Tim));
         DEBUG(1, "\n  Tim (hex) [%s]", BN_bn2hex(tag->Tim));
         DEBUG(1, "\n  index [%d]",  tag->index);
-        DEBUG(1, "\n  prf_size [%d]", tag->index_prf_size);
+        DEBUG(1, "\n  prf_size [%lu]", tag->index_prf_size);
         pdp_hexdump("  prf", i, tag->index_prf, tag->index_prf_size);
         pdp_hexdump(" Ser. tag", i, buf_ptr - tag_size, tag_size);
 #endif // _PDP_DEBUG

--- a/libpdp/src/pdp_key.c
+++ b/libpdp/src/pdp_key.c
@@ -128,6 +128,14 @@ int pdp_get_passphrase(const pdp_ctx_t *ctx, char *passwd, size_t len)
     if (!ctx || !passwd || !len)
         return -1;
 
+    if (ctx->opts & PDP_OPT_EXT_STRG) {
+        memset(passwd, 0, len);
+        const char* phrase = "hello";
+        size_t phrase_size = sizeof(phrase);
+        memcpy(passwd, phrase, phrase_size);
+        return 0;
+    }
+
     interactive = (ctx->opts & PDP_PW_NOINPUT) ? 0 : 1;
     if ((passwd2 = malloc(len)) == NULL)
         goto cleanup;

--- a/libpdp/src/pdp_misc.c
+++ b/libpdp/src/pdp_misc.c
@@ -228,6 +228,9 @@ int sample_prp_sans_replacement(const unsigned char *ki, unsigned int ki_size,
     M = samp_sz;
     V = 0;
     keyidx = 0;
+
+    if (N < M)
+        return -1;
     
     // a list of bits indicating set membership
     hist_size = pop_sz / (sizeof(unsigned char)*8);
@@ -523,11 +526,91 @@ unsigned int *gen_prp_pi(const unsigned char *key, unsigned int key_len,
         goto cleanup;
     if (sample_prp_sans_replacement(key, key_len, c, total, indices) != 0)
         goto cleanup;
+
     return indices;
 
 cleanup:
     if (indices) sfree(indices, c);
     return NULL;
+}
+
+
+/**
+ * @brief Determine endianness.
+ *
+ * @return 1 if the running platform is big endian, 0 otherwise.
+ **/
+int is_bigendian() {
+    static int calculated = 0;
+    static int bigendian = 0;
+    if (calculated)
+        return bigendian;
+
+    const int i = 1;
+    bigendian = ((*(char*)&i) == 0);
+    calculated = 1;
+
+    return bigendian;
+}
+
+
+/**
+ * @brief Determine endianness.
+ *
+ * @param[in] value     a 32-bit value
+ * @return Value converted to little endian.
+ **/
+__uint32_t uint32_to_little_endian(__uint32_t value) {
+    if (is_bigendian())
+        return bswap_32(value);
+
+    return value;
+}
+
+
+/**
+ * @brief Determine endianness.
+ *
+ * @param[in] value     a 64-bit value
+ * @return Value converted to little endian.
+ **/
+__uint64_t uint64_to_little_endian(__uint64_t value) {
+    if (is_bigendian())
+        return bswap_64(value);
+
+    return value;
+}
+
+
+/**
+ * @brief Determine endianness.
+ *
+ * @param[in] value     pointer to a 32-bit value
+ * @return Value converted to little endian.
+ **/
+__uint32_t uint32_in_expected_order(const unsigned char* value) {
+    __uint32_t result;
+    memcpy(&result, value, sizeof(result));
+    if (is_bigendian())
+        return bswap_32(result);
+
+    return result;
+}
+
+
+/**
+ * @brief Determine endianness.
+ *
+ * @param[in] value     pointer to a 64-bit value
+ * @return Value converted to little endian.
+ **/
+__uint64_t uint64_in_expected_order(const unsigned char* value) {
+    __uint64_t result;
+    memcpy(&result, value, sizeof(result));
+    if (is_bigendian())
+        return bswap_64(result);
+
+    return result;
 }
 
 

--- a/libpdp/src/pdp_misc.h
+++ b/libpdp/src/pdp_misc.h
@@ -48,6 +48,7 @@
 #define DEBUG(x, ...) \
     do { if (x) { \
             fprintf(stderr, __VA_ARGS__); \
+            fprintf(stderr, "\n"); \
             fflush(stderr); \
     }    } while(0)
 #else
@@ -108,6 +109,53 @@ void pdp_hexdump(const char* msg, unsigned int index,
 #endif // _PDP_DEBUG
 
 
+#ifdef _MSC_VER
+
+#include <stdlib.h>
+#define bswap_32(x) _byteswap_ulong(x)
+#define bswap_64(x) _byteswap_uint64(x)
+
+#elif defined(__APPLE__)
+
+// Mac OS X / Darwin features
+#include <libkern/OSByteOrder.h>
+#define bswap_32(x) OSSwapInt32(x)
+#define bswap_64(x) OSSwapInt64(x)
+
+#elif defined(__sun) || defined(sun)
+
+#include <sys/byteorder.h>
+#define bswap_32(x) BSWAP_32(x)
+#define bswap_64(x) BSWAP_64(x)
+
+#elif defined(__FreeBSD__)
+
+#include <sys/endian.h>
+#define bswap_32(x) bswap32(x)
+#define bswap_64(x) bswap64(x)
+
+#elif defined(__OpenBSD__)
+
+#include <sys/types.h>
+#define bswap_32(x) swap32(x)
+#define bswap_64(x) swap64(x)
+
+#elif defined(__NetBSD__)
+
+#include <sys/types.h>
+#include <machine/bswap.h>
+#if defined(__BSWAP_RENAME) && !defined(__bswap_32)
+#define bswap_32(x) bswap32(x)
+#define bswap_64(x) bswap64(x)
+#endif
+
+#else
+
+#include <byteswap.h>
+
+#endif
+
+
 /*
  * function prototypes - in pdp_misc.c
  */
@@ -127,6 +175,11 @@ unsigned char *gen_prf_f(const unsigned char *key, size_t key_size,
 BIGNUM *gen_prf_k(unsigned char *key, size_t key_len, unsigned int index);
 unsigned int *gen_prp_pi(const unsigned char *key, unsigned int key_len, 
         unsigned int total, unsigned int c);
+int is_bigendian();
+__uint32_t uint32_to_little_endian(__uint32_t value);
+__uint64_t uint64_to_little_endian(__uint64_t value);
+__uint32_t uint32_in_expected_order(const unsigned char* value);
+__uint64_t uint64_in_expected_order(const unsigned char* value);
 
 /*
  * function prototypes - in pdp_key.c

--- a/libpdp/src/sepdp/sepdp.c
+++ b/libpdp/src/sepdp/sepdp.c
@@ -268,7 +268,7 @@ static int sepdp_token_gen(const pdp_ctx_t *ctx, const pdp_sepdp_key_t *key,
     pdp_hexdump("  ki", token->index, ki, ki_size);
 
     DEBUG(1, "\n Writing - ");
-    DEBUG(1, "\n Token %02d", token->index);
+    DEBUG(1, "\n Token %02lu", token->index);
     pdp_hexdump("  iv", token->index, token->iv, token->iv_size);
     pdp_hexdump("  tok", token->index, token->tok, token->tok_size);
     pdp_hexdump("  mac", token->index, token->mac, token->mac_size);

--- a/libpdpgo/Makefile
+++ b/libpdpgo/Makefile
@@ -1,0 +1,79 @@
+.PHONY: all clean distclean mkdirs
+
+CC = gcc
+LD = gcc
+AR = ar
+
+#-----------------------------------------------------------------------------
+
+# BUILD directory
+ifndef BUILD
+    ifdef DEBUG
+        BUILD := build/debug
+    else
+        BUILD := build/release
+    endif
+endif
+
+#-----------------------------------------------------------------------------
+
+LIBPDP = ../libpdp
+LIBPDP_SRC = $(LIBPDP)/src
+INCLUDES  = -Iinc -Isrc -I$(LIBPDP)/inc -I$(LIBPDP_SRC)
+
+CFLAGS = -Wall -g $(INCLUDES)
+CFLAGS += -D_FILE_OFFSET_BITS=64
+CFLAGS += -D_THREAD_SUPPORT
+ifdef DEBUG
+    CFLAGS += -D_PDP_DEBUG
+endif
+
+LDFLAGS   = -lcrypto -pthread -lcurl -lcrypto -lxml2 -lz
+
+#-----------------------------------------------------------------------------
+
+LIBPDPGO = $(BUILD)/lib/libpdpgo.a
+
+OBJS  = pdp_generic.o pdp_misc.o pdp_key.o pdp_file.o pdp_s3.o
+OBJS += macpdp.o macpdp_key.o macpdp_file.o macpdp_s3.o
+OBJS += apdp.o apdp_key.o apdp_file.o apdp_s3.o apdp_serialize.o
+OBJS += mrpdp.o mrpdp_key.o mrpdp_file.o mrpdp_s3.o mrpdp_serialize.o
+OBJS += cpor.o cpor_key.o cpor_file.o cpor_s3.o cpor_serialize.o
+OBJS += sepdp.o sepdp_key.o sepdp_file.o sepdp_s3.o sepdp_serialize.o
+OBJS += pdpgo.o
+
+all: mkdirs $(LIBPDPGO)
+
+mkdirs:
+	@ mkdir -p $(BUILD)/lib
+	@ mkdir -p $(BUILD)/obj
+
+clean:
+	rm -rf $(BUILD)/obj/*.o
+
+distclean: clean
+	rm -rf $(LIBPDPGO)
+
+$(BUILD)/obj/%.o: src/%.c
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(BUILD)/obj/%.o: $(LIBPDP_SRC)/%.c
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(BUILD)/obj/%.o: $(LIBPDP_SRC)/apdp/%.c
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(BUILD)/obj/%.o: $(LIBPDP_SRC)/cpor/%.c
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(BUILD)/obj/%.o: $(LIBPDP_SRC)/macpdp/%.c
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(BUILD)/obj/%.o: $(LIBPDP_SRC)/mrpdp/%.c
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(BUILD)/obj/%.o: $(LIBPDP_SRC)/sepdp/%.c
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(LIBPDPGO): $(OBJS:%.o=$(BUILD)/obj/%.o)
+	$(AR) rs $@ $^

--- a/libpdpgo/inc/pdpgo.h
+++ b/libpdpgo/inc/pdpgo.h
@@ -80,6 +80,9 @@ void go_pdp_set_fail(go_pdp_data_t* pdp_data, char fail);
 
 // Proof Of Data Possession.
 int go_pdp_generate_keys(go_pdp_data_t* pdp_data);
+int go_pdp_generate_tags_init(go_pdp_data_t* pdp_data);
+int go_pdp_generate_tag(go_pdp_data_t* pdp_data, unsigned char *block, size_t block_len, int index);
+int go_pdp_generate_tags_finalize();
 int go_pdp_generate_tags(go_pdp_data_t* pdp_data);
 int go_pdp_generate_challenge(go_pdp_data_t* pdp_data);
 int go_pdp_generate_proof(go_pdp_data_t* pdp_data);

--- a/libpdpgo/inc/pdpgo.h
+++ b/libpdpgo/inc/pdpgo.h
@@ -1,0 +1,100 @@
+// Copyright 2018 ProximaX Limited. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+#ifndef PDPGO_H
+#define PDPGO_H
+
+#include <string.h>
+#include <pdp.h>
+#include <pdp_misc.h>
+#include <pdp/apdp.h>
+#include <pdp/apdp_types.h>
+#include <pdp/types.h>
+#include <apdp/apdp_misc.h>
+
+typedef int (*get_block_callback)(const pdp_ctx_t*, unsigned int, void*, unsigned int*);
+
+/// Holds data for PDP
+typedef struct {
+    // PDP context.
+    pdp_ctx_t ctx;
+    // Private key.
+    pdp_key_t private_key;
+    // Public key.
+    pdp_key_t public_key;
+    // Tags data.
+    pdp_tag_t tags;
+    // Verifier's challenge.
+    pdp_challenge_t verifier_challenge;
+    // Challenge for prover.
+    pdp_challenge_t prover_challenge;
+    // Proof of data possession.
+    pdp_proof_t proof;
+    // (For unit testing) If set to non-zero value all functions return error.
+    char fail;
+
+    // Hash of the file to verify.
+    unsigned char *file_hash;
+    // Size of the file hash (including terminating zero).
+    unsigned int file_hash_size;
+
+    // Serialized private key.
+    unsigned char *serialized_private_key;
+    // Size of the serialized private key.
+    unsigned int serialized_private_key_size;
+
+    // Serialized public key.
+    unsigned char *serialized_public_key;
+    // Size of the serialized public key.
+    unsigned int serialized_public_key_size;
+
+    // Serialized tags.
+    unsigned char *serialized_tags;
+    // Size of the serialized tags.
+    unsigned int serialized_tags_size;
+
+    // Serialized verifier's challenge.
+    unsigned char *serialized_verifier_challenge;
+    // Size of the serialized verifier's challenge.
+    unsigned int serialized_verifier_challenge_size;
+
+    // Serialized challenge for prover.
+    unsigned char *serialized_prover_challenge;
+    // Size of the serialized challenge for prover.
+    unsigned int serialized_prover_challenge_size;
+
+    // Serialized proof.
+    unsigned char *serialized_proof;
+    // Size of the serialized proof.
+    unsigned int serialized_proof_size;
+} go_pdp_data_t;
+
+// Data allocation/deallocation.
+go_pdp_data_t* create_apdp_data(off_t file_size, unsigned int block_size, unsigned short verbose, get_block_callback get_block);
+void go_pdp_data_free(go_pdp_data_t* pdp_data);
+
+// Set attributes.
+void go_pdp_set_file_hash(go_pdp_data_t* pdp_data, unsigned char* file_hash, unsigned int file_hash_size);
+void go_pdp_set_fail(go_pdp_data_t* pdp_data, char fail);
+
+// Proof Of Data Possession.
+int go_pdp_generate_keys(go_pdp_data_t* pdp_data);
+int go_pdp_generate_tags(go_pdp_data_t* pdp_data);
+int go_pdp_generate_challenge(go_pdp_data_t* pdp_data);
+int go_pdp_generate_proof(go_pdp_data_t* pdp_data);
+int go_pdp_verify_proof(go_pdp_data_t* pdp_data);
+
+//Struct serialization/deserialization.
+int go_pdp_serialize_keys(go_pdp_data_t* pdp_data);
+int go_pdp_deserialize_keys(go_pdp_data_t* pdp_data);
+int go_pdp_deserialize_public_key(go_pdp_data_t* pdp_data);
+int go_pdp_serialize_tags(go_pdp_data_t* pdp_data);
+int go_pdp_serialize_verifier_challenge(go_pdp_data_t* pdp_data);
+int go_pdp_deserialize_verifier_challenge(go_pdp_data_t* pdp_data);
+int go_pdp_serialize_prover_challenge(go_pdp_data_t* pdp_data);
+int go_pdp_deserialize_prover_challenge(go_pdp_data_t* pdp_data);
+int go_pdp_serialize_proof(go_pdp_data_t* pdp_data);
+int go_pdp_deserialize_proof(go_pdp_data_t* pdp_data);
+
+#endif //PDPGO_H

--- a/libpdpgo/src/pdpgo.c
+++ b/libpdpgo/src/pdpgo.c
@@ -1,0 +1,542 @@
+// Copyright 2018 ProximaX Limited. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+#include "pdpgo.h"
+
+int go_pdp_check_struct(go_pdp_data_t* pdp_data, const char* func) {
+    if (!pdp_data) {
+        DEBUG(1, "%s: null pointer passed", func);
+        return -1;
+    }
+
+    if (pdp_data->fail) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int apdp_get_tag_memory(const pdp_ctx_t* ctx, unsigned int index,
+                        void* buffer, unsigned int* length) {
+    pdp_apdp_tag_t** tag_ptr = (pdp_apdp_tag_t**) buffer;
+    go_pdp_data_t* pdp_data = NULL;
+    pdp_apdp_tag_t* tag = NULL;
+    unsigned char* serialized_tag = NULL;
+    unsigned int serialized_tag_start = 0, serialized_tag_size = 0;
+    int status = -1;
+
+    if (!ctx || !tag_ptr || !ctx->optional_data) return -1;
+
+    pdp_data = (go_pdp_data_t*)ctx->optional_data;
+    if (go_pdp_check_struct(pdp_data, __FUNCTION__)) return -1;
+
+    serialized_tag_size = apdp_serialized_tag_size(ctx);
+    serialized_tag_start = index * serialized_tag_size;
+    if (serialized_tag_start > pdp_data->serialized_tags_size) {
+        DEBUG(1, "%s: invalid tag index", __FUNCTION__);
+        goto cleanup;
+    }
+
+    serialized_tag = pdp_data->serialized_tags + serialized_tag_start;
+
+    // Allocate space for the tag
+    if ((tag = apdp_tag_new()) == NULL) goto cleanup;
+    if (*tag_ptr != NULL) {
+        // there is already a tag here, so free it
+        apdp_tag_free(*tag_ptr);
+    }
+    *tag_ptr = tag;
+
+    if (apdp_deserialize_tag(ctx, tag, serialized_tag, serialized_tag_size) != 0) {
+        DEBUG(1, "%s: couldn't deserialize tag", __FUNCTION__);
+        goto cleanup;
+    }
+
+    status = 0;
+
+cleanup:
+    if (status && tag_ptr && *tag_ptr) {
+        apdp_tag_free(*tag_ptr);
+        *tag_ptr = NULL;
+    }
+
+    return status;
+}
+
+int go_pdp_data_key_create(go_pdp_data_t* pdp_data, pdp_key_t* key) {
+    pdp_key_free(&pdp_data->ctx, key);
+    memset(key, 0, sizeof(pdp_key_t));
+
+    switch(pdp_data->ctx.algo) {
+        case PDP_APDP:
+            if ((key->apdp = malloc(sizeof(pdp_apdp_key_t))) == NULL) {
+                DEBUG(1, "%s: couldn't allocate A-PDP key struct", __FUNCTION__);
+                return -1;
+            }
+            memset(key->apdp, 0, sizeof(pdp_apdp_key_t));
+            return 0;
+        default:
+            DEBUG(1, "%s: algorithm is not supported (%u)", __FUNCTION__, pdp_data->ctx.algo);
+            break;
+    }
+
+    return -1;
+}
+
+int go_pdp_data_challenge_create(go_pdp_data_t* pdp_data, pdp_challenge_t* challenge) {
+    pdp_challenge_free(&pdp_data->ctx, challenge);
+    memset(challenge, 0, sizeof(pdp_challenge_t));
+
+    switch(pdp_data->ctx.algo) {
+        case PDP_APDP:
+            if ((challenge->apdp = malloc(sizeof(pdp_apdp_challenge_t))) == NULL) {
+                DEBUG(1, "%s: couldn't allocate A-PDP challenge struct", __FUNCTION__);
+                return -1;
+            }
+            memset(challenge->apdp, 0, sizeof(pdp_apdp_challenge_t));
+            return 0;
+        default:
+            DEBUG(1, "%s: algorithm is not supported (%u)", __FUNCTION__, pdp_data->ctx.algo);
+            break;
+    }
+
+    return -1;
+}
+
+int go_pdp_data_proof_create(go_pdp_data_t* pdp_data) {
+    pdp_proof_free(&pdp_data->ctx, &pdp_data->proof);
+    memset(&pdp_data->proof, 0, sizeof(pdp_proof_t));
+
+    switch(pdp_data->ctx.algo) {
+        case PDP_APDP:
+            if ((pdp_data->proof.apdp = malloc(sizeof(pdp_apdp_proof_t))) == NULL) {
+                DEBUG(1, "%s: couldn't allocate A-PDP proof struct", __FUNCTION__);
+                return -1;
+            }
+            memset(pdp_data->proof.apdp, 0, sizeof(pdp_apdp_proof_t));
+            return 0;
+        default:
+            DEBUG(1, "%s: algorithm is not supported (%u)", __FUNCTION__, pdp_data->ctx.algo);
+            break;
+    }
+
+    return -1;
+}
+
+int go_pdp_serialize_keys(go_pdp_data_t* pdp_data) {
+    if (go_pdp_check_struct(pdp_data, __FUNCTION__)) {
+        return -1;
+    }
+
+    if (pdp_data->ctx.algo != PDP_APDP) {
+        DEBUG(1, "%s: algorithm is not supported (%u)", __FUNCTION__, pdp_data->ctx.algo);
+        return -1;
+    }
+
+    if (!pdp_data->private_key.apdp) {
+        DEBUG(1, "%s: no keys", __FUNCTION__);
+        return -1;
+    }
+
+    sfree(pdp_data->serialized_private_key, pdp_data->serialized_private_key_size);
+    pdp_data->serialized_private_key = NULL;
+    pdp_data->serialized_private_key_size = 0;
+
+    sfree(pdp_data->serialized_public_key, pdp_data->serialized_public_key_size);
+    pdp_data->serialized_public_key = NULL;
+    pdp_data->serialized_public_key_size = 0;
+
+    return pdp_key_store(&pdp_data->ctx, &pdp_data->private_key, NULL,
+            &pdp_data->serialized_private_key, &pdp_data->serialized_private_key_size,
+            &pdp_data->serialized_public_key, &pdp_data->serialized_public_key_size);
+}
+
+int go_pdp_deserialize_keys(go_pdp_data_t* pdp_data) {
+    if (go_pdp_check_struct(pdp_data, __FUNCTION__)) {
+        return -1;
+    }
+
+    if (pdp_data->ctx.algo != PDP_APDP) {
+        DEBUG(1, "%s: algorithm is not supported (%u)", __FUNCTION__, pdp_data->ctx.algo);
+        return -1;
+    }
+
+    if (go_pdp_data_key_create(pdp_data, &pdp_data->private_key)) {
+        DEBUG(1, "%s: couldn't create private key", __FUNCTION__);
+        return -1;
+    }
+
+    if (go_pdp_data_key_create(pdp_data, &pdp_data->public_key)) {
+        DEBUG(1, "%s: couldn't create public key", __FUNCTION__);
+        return -1;
+    }
+
+    return pdp_key_open(&pdp_data->ctx, &pdp_data->private_key, &pdp_data->public_key, NULL,
+            pdp_data->serialized_private_key, pdp_data->serialized_public_key);
+}
+
+int go_pdp_deserialize_public_key(go_pdp_data_t* pdp_data) {
+    if (go_pdp_check_struct(pdp_data, __FUNCTION__)) {
+        return -1;
+    }
+
+    if (pdp_data->ctx.algo != PDP_APDP) {
+        DEBUG(1, "%s: algorithm is not supported (%u)", __FUNCTION__, pdp_data->ctx.algo);
+        return -1;
+    }
+
+    if (go_pdp_data_key_create(pdp_data, &pdp_data->public_key)) {
+        DEBUG(1, "%s: couldn't create public key", __FUNCTION__);
+        return -1;
+    }
+
+    return pdp_key_open(&pdp_data->ctx, NULL, &pdp_data->public_key, NULL, NULL, pdp_data->serialized_public_key);
+}
+
+int go_pdp_serialize_tags(go_pdp_data_t* pdp_data) {
+    if (go_pdp_check_struct(pdp_data, __FUNCTION__)) {
+        return -1;
+    }
+
+    if (!pdp_data->tags.apdp) {
+        DEBUG(1, "%s: no tags", __FUNCTION__);
+        return -1;
+    }
+
+    sfree(pdp_data->serialized_tags, pdp_data->serialized_tags_size);
+
+    switch(pdp_data->ctx.algo) {
+        case PDP_APDP:
+            return apdp_serialize_tags(&pdp_data->ctx, pdp_data->tags.apdp, &pdp_data->serialized_tags,
+                                       &pdp_data->serialized_tags_size);
+        default:
+            DEBUG(1, "%s: algorithm is not supported (%u)", __FUNCTION__, pdp_data->ctx.algo);
+            break;
+    }
+
+    return -1;
+}
+
+int go_pdp_serialize_verifier_challenge(go_pdp_data_t* pdp_data) {
+    if (go_pdp_check_struct(pdp_data, __FUNCTION__)) {
+        return -1;
+    }
+
+    if (!pdp_data->verifier_challenge.apdp) {
+        DEBUG(1, "%s: no verifier challenge", __FUNCTION__);
+        return -1;
+    }
+
+    sfree(pdp_data->serialized_verifier_challenge, pdp_data->serialized_verifier_challenge_size);
+
+    switch(pdp_data->ctx.algo) {
+        case PDP_APDP:
+            return apdp_serialize_challenge(&pdp_data->ctx, pdp_data->verifier_challenge.apdp,
+                    &pdp_data->serialized_verifier_challenge,
+                    &pdp_data->serialized_verifier_challenge_size);
+        default:
+            DEBUG(1, "%s: algorithm is not supported (%u)", __FUNCTION__, pdp_data->ctx.algo);
+            break;
+    }
+
+    return -1;
+}
+
+int go_pdp_deserialize_verifier_challenge(go_pdp_data_t* pdp_data) {
+    if (go_pdp_check_struct(pdp_data, __FUNCTION__)) {
+        return -1;
+    }
+
+    if (go_pdp_data_challenge_create(pdp_data, &pdp_data->verifier_challenge)) {
+        DEBUG(1, "%s: couldn't create verifier challenge", __FUNCTION__);
+        return -1;
+    }
+
+    switch(pdp_data->ctx.algo) {
+        case PDP_APDP:
+            if ((pdp_data->verifier_challenge.apdp = malloc(sizeof(pdp_apdp_challenge_t))) == NULL) {
+                DEBUG(1, "%s: couldn't allocate A-PDP challenge struct", __FUNCTION__);
+                return -1;
+            }
+            memset(pdp_data->verifier_challenge.apdp, 0, sizeof(pdp_apdp_challenge_t));
+            return apdp_deserialize_challenge(&pdp_data->ctx, pdp_data->verifier_challenge.apdp,
+                    pdp_data->serialized_verifier_challenge,
+                    pdp_data->serialized_verifier_challenge_size);
+        default:
+            DEBUG(1, "%s: algorithm is not supported (%u)", __FUNCTION__, pdp_data->ctx.algo);
+            break;
+    }
+
+    return -1;
+}
+
+int go_pdp_serialize_prover_challenge(go_pdp_data_t* pdp_data) {
+    if (go_pdp_check_struct(pdp_data, __FUNCTION__)) {
+        return -1;
+    }
+
+    if (!pdp_data->prover_challenge.apdp) {
+        DEBUG(1, "%s: no prover challenge", __FUNCTION__);
+        return -1;
+    }
+
+    sfree(pdp_data->serialized_prover_challenge, pdp_data->serialized_prover_challenge_size);
+
+    switch(pdp_data->ctx.algo) {
+        case PDP_APDP:
+            return apdp_serialize_challenge(&pdp_data->ctx, pdp_data->prover_challenge.apdp,
+                    &pdp_data->serialized_prover_challenge,
+                    &pdp_data->serialized_prover_challenge_size);
+        default:
+            DEBUG(1, "%s: algorithm is not supported (%u)", __FUNCTION__, pdp_data->ctx.algo);
+            break;
+    }
+
+    return -1;
+}
+
+int go_pdp_deserialize_prover_challenge(go_pdp_data_t* pdp_data) {
+    if (go_pdp_check_struct(pdp_data, __FUNCTION__)) {
+        return -1;
+    }
+
+    if (go_pdp_data_challenge_create(pdp_data, &pdp_data->prover_challenge)) {
+        DEBUG(1, "%s: couldn't create prover challenge", __FUNCTION__);
+        return -1;
+    }
+
+    switch(pdp_data->ctx.algo) {
+        case PDP_APDP:
+            if ((pdp_data->prover_challenge.apdp = malloc(sizeof(pdp_apdp_challenge_t))) == NULL) {
+                DEBUG(1, "%s: couldn't allocate A-PDP challenge struct", __FUNCTION__);
+                return -1;
+            }
+            memset(pdp_data->prover_challenge.apdp, 0, sizeof(pdp_apdp_challenge_t));
+            return apdp_deserialize_challenge(&pdp_data->ctx, pdp_data->prover_challenge.apdp,
+                    pdp_data->serialized_prover_challenge,
+                    pdp_data->serialized_prover_challenge_size);
+        default:
+            DEBUG(1, "%s: algorithm is not supported (%u)", __FUNCTION__, pdp_data->ctx.algo);
+            break;
+    }
+
+    return -1;
+}
+
+int go_pdp_serialize_proof(go_pdp_data_t* pdp_data) {
+    if (go_pdp_check_struct(pdp_data, __FUNCTION__)) {
+        return -1;
+    }
+
+    if (!pdp_data->proof.apdp) {
+        DEBUG(1, "%s: no proof", __FUNCTION__);
+        return -1;
+    }
+
+    sfree(pdp_data->serialized_proof, pdp_data->serialized_proof_size);
+
+    switch(pdp_data->ctx.algo) {
+        case PDP_APDP:
+            return apdp_serialize_proof(&pdp_data->ctx, pdp_data->proof.apdp, &pdp_data->serialized_proof,
+                                        &pdp_data->serialized_proof_size);
+        default:
+            DEBUG(1, "%s: algorithm is not supported (%u)", __FUNCTION__, pdp_data->ctx.algo);
+            break;
+    }
+
+    return -1;
+}
+
+int go_pdp_deserialize_proof(go_pdp_data_t* pdp_data) {
+    if (go_pdp_check_struct(pdp_data, __FUNCTION__)) {
+        return -1;
+    }
+
+    if (go_pdp_data_proof_create(pdp_data)) {
+        DEBUG(1, "%s: couldn't create proof", __FUNCTION__);
+        return -1;
+    }
+
+    switch(pdp_data->ctx.algo) {
+        case PDP_APDP:
+            return apdp_deserialize_proof(&pdp_data->ctx, pdp_data->proof.apdp, pdp_data->serialized_proof,
+                                        pdp_data->serialized_proof_size);
+        default:
+            DEBUG(1, "%s: algorithm is not supported (%u)", __FUNCTION__, pdp_data->ctx.algo);
+            break;
+    }
+
+    return -1;
+}
+
+go_pdp_data_t* create_apdp_data(off_t file_size, unsigned int block_size, unsigned short verbose, get_block_callback get_block) {
+    if (!file_size) {
+        DEBUG(1, "%s: file size is not set", __FUNCTION__);
+        return NULL;
+    }
+
+    go_pdp_data_t* pdp_data = NULL;
+
+    if ((pdp_data = malloc(sizeof(go_pdp_data_t))) == NULL) {
+        DEBUG(1, "%s: couldn't allocate PDP data", __FUNCTION__);
+        goto cleanup;
+    }
+
+    memset(pdp_data, 0, sizeof(go_pdp_data_t));
+    pdp_data->ctx.algo = PDP_APDP;
+
+    if (pdp_ctx_init(&pdp_data->ctx)) {
+        DEBUG(1, "%s: couldn't init PDP context", __FUNCTION__);
+        goto cleanup;
+    }
+
+    pdp_data->ctx.opts |= PDP_OPT_EXT_STRG;
+    pdp_data->ctx.opts |= PDP_OPT_THREADED;
+    pdp_data->ctx.file_st_size = file_size;
+    pdp_data->ctx.apdp_param->block_size = block_size;
+    pdp_data->ctx.verbose = verbose;
+
+    if (pdp_ctx_create(&pdp_data->ctx, NULL, NULL)) {
+        DEBUG(1, "%s: couldn't populate PDP context", __FUNCTION__);
+        goto cleanup;
+    }
+
+    pdp_data->ctx.ops->get_block = get_block;
+    pdp_data->ctx.ops->get_tag = apdp_get_tag_memory;
+    pdp_data->ctx.optional_data = pdp_data;
+
+    return pdp_data;
+
+cleanup:
+    if (pdp_data) {
+        sfree(pdp_data, sizeof(go_pdp_data_t));
+    }
+
+    return NULL;
+}
+
+void go_pdp_data_fields_free(go_pdp_data_t* pdp_data) {
+    pdp_key_free(&pdp_data->ctx, &pdp_data->private_key);
+    pdp_key_free(&pdp_data->ctx, &pdp_data->public_key);
+    pdp_tags_free(&pdp_data->ctx, &pdp_data->tags);
+    pdp_challenge_free(&pdp_data->ctx, &pdp_data->verifier_challenge);
+    pdp_challenge_free(&pdp_data->ctx, &pdp_data->prover_challenge);
+    pdp_proof_free(&pdp_data->ctx, &pdp_data->proof);
+    sfree(pdp_data->file_hash, pdp_data->file_hash_size);
+    sfree(pdp_data->serialized_public_key, pdp_data->serialized_public_key_size);
+    sfree(pdp_data->serialized_tags, pdp_data->serialized_tags_size);
+    sfree(pdp_data->serialized_prover_challenge, pdp_data->serialized_prover_challenge_size);
+    sfree(pdp_data->serialized_proof, pdp_data->serialized_proof_size);
+}
+
+void go_pdp_data_free(go_pdp_data_t* pdp_data) {
+    if (go_pdp_check_struct(pdp_data, __FUNCTION__)) {
+        return;
+    }
+    go_pdp_data_fields_free(pdp_data);
+    pdp_ctx_free(&pdp_data->ctx);
+    sfree(pdp_data, sizeof(go_pdp_data_t));
+}
+
+void go_pdp_set_file_hash(go_pdp_data_t* pdp_data, unsigned char* file_hash, unsigned int file_hash_size) {
+    sfree(pdp_data->file_hash, pdp_data->file_hash_size);
+    pdp_data->file_hash = file_hash;
+    pdp_data->file_hash_size = file_hash_size;
+}
+
+void go_pdp_set_fail(go_pdp_data_t* pdp_data, char fail) {
+    if (pdp_data) {
+        pdp_data->fail = fail;
+    }
+}
+
+int go_pdp_generate_keys(go_pdp_data_t* pdp_data) {
+    if (go_pdp_check_struct(pdp_data, __FUNCTION__)) {
+        return -1;
+    }
+
+    // Generate keys.
+    if (pdp_key_gen(&pdp_data->ctx, &pdp_data->private_key, &pdp_data->public_key)) {
+        DEBUG(1, "%s: couldn't generate keys", __FUNCTION__);
+        goto cleanup;
+    }
+
+    return 0;
+
+cleanup:
+    pdp_key_free(&pdp_data->ctx, &pdp_data->private_key);
+    pdp_key_free(&pdp_data->ctx, &pdp_data->public_key);
+
+    return -1;
+}
+
+int go_pdp_generate_tags(go_pdp_data_t* pdp_data) {
+    if (go_pdp_check_struct(pdp_data, __FUNCTION__)) {
+        return -1;
+    }
+
+    if (pdp_tags_gen(&pdp_data->ctx, &pdp_data->private_key, &pdp_data->tags)) {
+        DEBUG(1, "%s: couldn't generate tags", __FUNCTION__);
+        goto cleanup;
+    }
+
+    return 0;
+
+cleanup:
+    pdp_tags_free(&pdp_data->ctx, &pdp_data->tags);
+
+    return -1;
+}
+
+int go_pdp_generate_challenge(go_pdp_data_t* pdp_data) {
+    if (go_pdp_check_struct(pdp_data, __FUNCTION__)) {
+        return -1;
+    }
+
+    // Generate verifier's challenge.
+    if (pdp_challenge_gen(&pdp_data->ctx, &pdp_data->private_key, &pdp_data->verifier_challenge)) {
+        DEBUG(1, "%s: couldn't generate verifier's challenge", __FUNCTION__);
+        goto cleanup;
+    }
+
+    // Generate challenge for prover.
+    if (pdp_challenge_for_prover(&pdp_data->ctx, &pdp_data->verifier_challenge, &pdp_data->prover_challenge)) {
+        DEBUG(1, "%s: couldn't generate challenge for prover", __FUNCTION__);
+        goto cleanup;
+    }
+
+    return 0;
+
+cleanup:
+    go_pdp_data_fields_free(pdp_data);
+
+    return -1;
+}
+
+int go_pdp_generate_proof(go_pdp_data_t* pdp_data) {
+    if (go_pdp_check_struct(pdp_data, __FUNCTION__)) {
+        return -1;
+    }
+
+    if (pdp_proof_gen(&pdp_data->ctx, &pdp_data->public_key, &pdp_data->prover_challenge, &pdp_data->proof)) {
+        DEBUG(1, "%s: couldn't generate proof", __FUNCTION__);
+        goto cleanup;
+    }
+
+    return 0;
+
+cleanup:
+    pdp_proof_free(&pdp_data->ctx, &pdp_data->proof);
+
+    return -1;
+}
+
+int go_pdp_verify_proof(go_pdp_data_t* pdp_data) {
+    if (go_pdp_check_struct(pdp_data, __FUNCTION__)) {
+        return -1;
+    }
+
+    return pdp_proof_verify(&pdp_data->ctx, &pdp_data->private_key, &pdp_data->verifier_challenge,
+            &pdp_data->proof);
+}

--- a/tools/src/pdp_bench.c
+++ b/tools/src/pdp_bench.c
@@ -503,7 +503,7 @@ int main(int argc, char **argv)
     // if we do an op that needs a key, prepare the key
     if (params.keypath) {
         VERBOSE(params.verb, "Trying to open keys...");
-        if ((error = pdp_key_open(ctx, &key, &pk, params.keypath)) != 0) {
+        if ((error = pdp_key_open(ctx, &key, &pk, params.keypath, NULL)) != 0) {
             VERBOSE(params.verb, "None found at [%s].\n", params.keypath);
         } else {
             key_stat = 1;
@@ -520,7 +520,7 @@ int main(int argc, char **argv)
     }
     if (!key_stat && params.keypath) {
         VERBOSE(params.verb, "Store keys...");
-        if ((error = pdp_key_store(ctx, &key, params.keypath)) != 0) {
+        if ((error = pdp_key_store(ctx, &key, params.keypath, NULL, NULL, NULL, NULL)) != 0) {
             ERROR("error: couldn't store keys at [%s]", params.keypath);
             goto cleanup;
         }


### PR DESCRIPTION
The new library is added to be used by GO code. Memory management is performed by the library itself. The library functions are declared in pdpgo.h and implemented in pdpgo.c